### PR TITLE
Stick the Table Head to the Top

### DIFF
--- a/library/Falcon/Manager.php
+++ b/library/Falcon/Manager.php
@@ -45,6 +45,15 @@ class Falcon_Manager extends Falcon_Autohooker {
 					border-right: none;
 				}
 
+				.falcon-grid thead {
+					background: inherit;
+					position: sticky;
+					top: 0;
+				}
+				html.wp-toolbar .falcon-grid thead {
+					top: 32px;
+				}
+
 				.falcon-grid thead th,
 				.falcon-grid thead td,
 				.falcon-grid tbody td {


### PR DESCRIPTION
This PR adds some styling for the `.falcon-grid` (table) head to stick it to the top. This is useful for larger multisite installations where you have more sites than fit on your screen. (Well, or you just might have a tiny screen.) Without the labels in the head, you might not know what the radio buttons are for.

This is how it will look with this PR merged:

![image](https://user-images.githubusercontent.com/6049306/106874863-5a5cd580-66d6-11eb-89a4-2269a4e933aa.png)

Please note that I (only) added basic awareness of the admin bar. I did not add any viewport-specific styles (where the top padding is different).